### PR TITLE
이미지 업로드 위치 변경 (로컬 -> S3)

### DIFF
--- a/backend/src/main/java/com/zerogift/backend/product/controller/ProductImageController.java
+++ b/backend/src/main/java/com/zerogift/backend/product/controller/ProductImageController.java
@@ -1,8 +1,6 @@
 package com.zerogift.backend.product.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,12 +32,6 @@ public class ProductImageController {
             @RequestParam("files") MultipartFile[] request) {
         return ResponseEntity.ok().body(
             Result.builder().data(productImageService.upload(request)).build());
-    }
-
-    @GetMapping("img/{url}")
-    public ResponseEntity<byte[]> displayImage(
-            @PathVariable String url) {
-        return productImageService.display(url);
     }
 
     private ResponseEntity<Result<?>> getResponse(int status, ProductErrorCode errorCode) {

--- a/backend/src/main/java/com/zerogift/backend/product/service/ProductImageService.java
+++ b/backend/src/main/java/com/zerogift/backend/product/service/ProductImageService.java
@@ -1,23 +1,16 @@
 package com.zerogift.backend.product.service;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.zerogift.backend.product.dto.ImageUploadResponse;
 import com.zerogift.backend.product.entity.ProductImage;
 import com.zerogift.backend.product.repository.ProductImageRepository;
+import com.zerogift.backend.util.FileUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,21 +18,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductImageService {
     private final ProductImageRepository productImageRepository;
-
-    private static final String UPLOAD_PATH = "/opt/zerogift/upload/";
+    private final FileUtil fileUtil;
 
     public List<ImageUploadResponse> upload(MultipartFile[] request) {
-        createDirIfNotExist();
         List<ImageUploadResponse> results = new ArrayList<>();
         for (MultipartFile file : request) {
-            String originalFileName = null, uuid = null, ext = null;
-            byte[] bytes = null;
+            String url = null, originalFileName = file.getOriginalFilename();
             try {
-                originalFileName = file.getOriginalFilename();
-                bytes = file.getBytes();
-                uuid = UUID.nameUUIDFromBytes(bytes).toString();
-                ext = originalFileName.substring(originalFileName.lastIndexOf(".") + 1);
-                Files.write(Paths.get(UPLOAD_PATH + uuid + "." + ext), bytes);
+                url = fileUtil.update(file);
             } catch (IOException e) {
                 results.add(ImageUploadResponse.builder()
                                                .success(false)
@@ -47,7 +33,7 @@ public class ProductImageService {
                                                .build());
                 continue;
             }
-            ProductImage productImage = ProductImage.builder().url(uuid + "." + ext).build();
+            ProductImage productImage = ProductImage.builder().url(url).build();
             productImageRepository.save(productImage);
             results.add(ImageUploadResponse.builder()
                                            .productImageId(productImage.getId())
@@ -56,25 +42,5 @@ public class ProductImageService {
                                            .build());
         };
         return results;
-    }
-
-    public ResponseEntity<byte[]> display(String url) {
-        ResponseEntity<byte[]> response = null;
-        File file = new File(UPLOAD_PATH + url);
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.add("Content-type", Files.probeContentType(file.toPath()));
-            response = new ResponseEntity<>(FileCopyUtils.copyToByteArray(file), headers, HttpStatus.OK);
-        } catch (IOException e) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-        return response;
-    }
-
-    private void createDirIfNotExist() {
-        File dir = new File(UPLOAD_PATH);
-        if (!dir.exists()){
-            dir.mkdir();
-        }
     }
 }

--- a/backend/src/main/java/com/zerogift/backend/product/service/ProductService.java
+++ b/backend/src/main/java/com/zerogift/backend/product/service/ProductService.java
@@ -1,7 +1,6 @@
 package com.zerogift.backend.product.service;
 
 import java.io.File;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -44,8 +43,6 @@ public class ProductService {
     private final ProductImageRepository productImageRepository;
     private final MemberRepository memberRepository;
 
-    private static final String UPLOAD_PATH = "/opt/zerogift/upload/";
-
     @Transactional
     public NewProductResponse addProduct(NewProductRequest request, String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow(
@@ -86,11 +83,6 @@ public class ProductService {
         Product product = optionalProduct.get();
         if (!product.getMember().equals(member)) return badRequest(403, ProductErrorCode.OWNED_BY_SOMEONE_ELSE);
         for (ProductImage image : productImageRepository.findAllByProduct(product)) {
-            String url = image.getUrl();
-            if (productImageRepository.countByUrl(url) == 1) {
-                File file = new File(UPLOAD_PATH + url);
-                file.delete();
-            }
             productImageRepository.delete(image);
         }
         productRepository.delete(product);


### PR DESCRIPTION
## 이미지 업로드 위치 변경 (로컬 -> S3)

## Kinds ✅
- [ ] Feature
- [ ] Bug Fix
- [ ] Infra

## Description ✏
로컬 스토리지 대신에 S3에 저장합니다. 로컬 스토리지의 이미지를 보여주는 기능도 삭제되었습니다.
추가로 원래 Product 삭제시 중복이 아닌 이미지를 스토리지에서 삭제하는 기능이 있었는데,
이 부분이 빠지면서 현재 삭제되는 Product와 연결된 ProductImage의 DB 엔트리들을 삭제하는 기능만 남았습니다.

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [x] 구현 기능 테스트
리액트로 S3에 업로드하고 다운로드 되는 것 확인했습니다.

## To Reviewers 🙏

