### PR TITLE
선물함 응답값 추가 ( 선물 보낸 사람, 상품 아이디, 메시지 여부, 리뷰 여부)

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,0 +1,16 @@
+= Zero gift REST Docs (글의 제목)
+zerogift(부제)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left // toc (Table Of Contents)를 문서의 좌측에 두기
+:toclevels: 2
+:sectlinks:
+
+[[giftBox-API]]
+== 선물함 리스트 API
+operation::giftBox[snippets='http-request,path-parameters,http-response,response-fields']
+
+[[gitBoxDetail-API]]
+=== 선물함 상세보기 API
+operation::giftBoxDetail[snippets='http-request,path-parameters,http-response,response-fields']

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -12,5 +12,5 @@ zerogift(부제)
 operation::giftBox[snippets='http-request,path-parameters,http-response,response-fields']
 
 [[gitBoxDetail-API]]
-=== 선물함 상세보기 API
+== 선물함 상세보기 API
 operation::giftBoxDetail[snippets='http-request,path-parameters,http-response,response-fields']

--- a/backend/src/main/java/com/zerogift/backend/giftBox/dto/GiftBoxDto.java
+++ b/backend/src/main/java/com/zerogift/backend/giftBox/dto/GiftBoxDto.java
@@ -14,12 +14,23 @@ public class GiftBoxDto {
     private String imageUrl;
     private String description;
     private boolean use;
+    private Long sendId;
+    private String sendNickname;
+    private Long productId;
+    private boolean answer;
+    private boolean review;
 
-    public GiftBoxDto(Long id, String name, String imageUrl, String description, boolean use) {
+    public GiftBoxDto(Long id, String name, String imageUrl, String description, boolean use,
+        Long sendId, String sendNickname, Long productId, boolean answer, boolean review) {
         this.id = id;
         this.name = name;
         this.imageUrl = imageUrl;
         this.description = description;
         this.use = use;
+        this.sendId = sendId;
+        this.sendNickname = sendNickname;
+        this.productId = productId;
+        this.answer = answer;
+        this.review = review;
     }
 }

--- a/backend/src/main/java/com/zerogift/backend/giftBox/entity/GiftBox.java
+++ b/backend/src/main/java/com/zerogift/backend/giftBox/entity/GiftBox.java
@@ -41,6 +41,9 @@ public class GiftBox extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean answer;  // 답변을 하였는지
 
+    @Column(nullable = false)
+    private boolean review;
+
     @ManyToOne
     @JoinColumn(name = "send_member_id")
     private Member sendMember;  // 보낸 사람
@@ -67,6 +70,7 @@ public class GiftBox extends BaseTimeEntity {
         this.recipientMember = recipientMember;
         this.product = product;
         this.payHistory = payHistory;
+        this.review = false;
         this.isUse = false;
         this.answer = false;
         this.expireDate = LocalDate.now().plusMonths(1);
@@ -82,6 +86,10 @@ public class GiftBox extends BaseTimeEntity {
 
     public void use() {
         this.isUse = true;
+    }
+
+    public void review() {
+        this.review = true;
     }
 
 }

--- a/backend/src/main/java/com/zerogift/backend/giftBox/repository/GiftBoxRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/zerogift/backend/giftBox/repository/GiftBoxRepositoryCustomImpl.java
@@ -32,10 +32,16 @@ public class GiftBoxRepositoryCustomImpl implements GiftBoxRepositoryCustom {
                 product.name,
                 product.mainImageUrl,
                 product.description,
-                giftBox.isUse
+                giftBox.isUse,
+                member.id,
+                member.nickname,
+                product.id,
+                giftBox.answer,
+                giftBox.review
             ))
             .from(giftBox)
             .innerJoin(giftBox.product, product)
+            .innerJoin(giftBox.sendMember, member)
             .where(
                 eqRecipientMember(loginMember))
             .orderBy(giftBox.createdDate.asc())

--- a/backend/src/main/java/com/zerogift/backend/pay/service/LockService.java
+++ b/backend/src/main/java/com/zerogift/backend/pay/service/LockService.java
@@ -39,7 +39,9 @@ public class LockService {
     }
 
     public void unlock(RLock lock) {
-        lock.unlock();
+        if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
     }
 
 }

--- a/backend/src/main/java/com/zerogift/backend/review/service/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/zerogift/backend/review/service/ReviewServiceImpl.java
@@ -23,19 +23,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class ReviewServiceImpl implements ReviewService{
 
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
     private final MemberRepository memberRepository;
     private final GiftBoxRepository giftBoxRepository;
+
 
     @Override
     public ReviewResponse addReview(LoginInfo loginInfo, Long productId, ReviewInput reviewInput) {
@@ -54,6 +56,7 @@ public class ReviewServiceImpl implements ReviewService{
             throw new ReviewException(ReviewErrorCode.ADD_REVIEW_AFTER_USE);
         }
 
+        giftBox.review();
         // 리뷰 내용 저장
         Review review = Review.builder()
                 .rank(reviewInput.getRank())
@@ -68,7 +71,6 @@ public class ReviewServiceImpl implements ReviewService{
         return ReviewResponse.of(review);
     }
 
-    @Transactional
     @Override
     public ReviewResponse modifyReview(LoginInfo loginInfo, Long reviewId, ReviewInput reviewInput) {
         // 회원 정보 가져오기
@@ -99,6 +101,7 @@ public class ReviewServiceImpl implements ReviewService{
         reviewRepository.delete(review);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<ReviewResponse> userReviewList(LoginInfo loginInfo) {
         // 회원 정보 가져오기
@@ -111,6 +114,7 @@ public class ReviewServiceImpl implements ReviewService{
         return reviewResponseList;
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<ReviewResponse> productReviewList(Long productId) {
         // 상품 정보 가져오기

--- a/backend/src/test/java/com/zerogift/backend/acceptance/giftBox/GiftBoxAcceptanceTest.java
+++ b/backend/src/test/java/com/zerogift/backend/acceptance/giftBox/GiftBoxAcceptanceTest.java
@@ -92,7 +92,7 @@ class GiftBoxAcceptanceTest extends AcceptanceTest {
         GiftBoxDto extract = response.jsonPath().getObject("data[0]", GiftBoxDto.class);
 
         assertThat(extract).isEqualTo(
-            new GiftBoxDto(1L, "test", "https://test.com", "test 설명", false));
+            new GiftBoxDto(1L, "test", "https://test.com", "test 설명", false, 회원.getId(), 회원.getNickname(), 상품_아이디, false, false));
     }
 
 

--- a/backend/src/test/java/com/zerogift/backend/documentaion/giftbox/FindByGiftBoxListStep.java
+++ b/backend/src/test/java/com/zerogift/backend/documentaion/giftbox/FindByGiftBoxListStep.java
@@ -22,9 +22,9 @@ public class FindByGiftBoxListStep {
     public static List<GiftBoxDto> 선물함_리스트_응답_생성() {
         return List.of(
             new GiftBoxDto(1L, "아이스 아메리카노", "https://img.danawa.com/prod_img/500000/609/014/img/3014609_1.jpg?shrink=330:330&_v=20220524144914",
-                "더운날에는 아이스 아메리카노 어떠세요?", false),
+                "더운날에는 아이스 아메리카노 어떠세요?", false, 1L, "제로베이스", 1L, false, false),
             new GiftBoxDto(2L, "두번쨰 아이스 아메리카노", "https://img.danawa.com/prod_img/500000/609/014/img/3014609_1.jpg?shrink=330:330&_v=20220524144914",
-                "조금 싼 아이스 아메리카노", false)
+                "조금 싼 아이스 아메리카노", false, 2L, "패스트캠퍼스", 2L, false, false)
         );
     }
 
@@ -57,7 +57,12 @@ public class FindByGiftBoxListStep {
             fieldWithPath("data[].name").type(JsonFieldType.STRING).description("상품 이름"),
             fieldWithPath("data[].imageUrl").type(JsonFieldType.STRING).description("상품 대표 이미지"),
             fieldWithPath("data[].description").type(JsonFieldType.STRING).description("상품 설명"),
-            fieldWithPath("data[].use").type(JsonFieldType.BOOLEAN).description("사용 여부")
+            fieldWithPath("data[].use").type(JsonFieldType.BOOLEAN).description("사용 여부"),
+            fieldWithPath("data[].sendId").type(JsonFieldType.NUMBER).description("선물한 사람 아이디"),
+            fieldWithPath("data[].sendNickname").type(JsonFieldType.STRING).description("선물한 사람 닉네임"),
+            fieldWithPath("data[].productId").type(JsonFieldType.NUMBER).description("상품 아이디"),
+            fieldWithPath("data[].answer").type(JsonFieldType.BOOLEAN).description("감사 메시지 여부"),
+            fieldWithPath("data[].review").type(JsonFieldType.BOOLEAN).description("리뷰 여부")
         );
     }
 

--- a/backend/src/test/java/com/zerogift/backend/giftBox/service/GiftBoxServiceTest.java
+++ b/backend/src/test/java/com/zerogift/backend/giftBox/service/GiftBoxServiceTest.java
@@ -84,7 +84,8 @@ class GiftBoxServiceTest extends AcceptanceTest {
     void findByGiftBoxListTest() {
         List<GiftBoxDto> giftBoxDtoPages = giftBoxService.findByGiftBoxList(adminInfo, new MyPageableDto(0, 10));
 
-        GiftBoxDto extract = new GiftBoxDto(giftBox.getId(), product.getName(), null, product.getDescription(), false);
+        GiftBoxDto extract = new GiftBoxDto(giftBox.getId(), product.getName(), null, product.getDescription(), false,
+            member.getId(), member.getNickname(), product.getId(), false, false);
 
         assertThat(giftBoxDtoPages).containsExactly(extract);
     }


### PR DESCRIPTION
## <선물함 응답값 추가>

## Kinds ✅
- [x] Feature
- [ ] Bug Fix
- [ ] Infra

## Description ✏
PR에 관한 설명을 작성해주세요.

1. 선물함 리스트 조회 API 응답값 수정

- response 응답 설명
![스크린샷 2022-09-24 오후 3 57 41](https://user-images.githubusercontent.com/24979159/192084637-76980ac4-1b8d-46a7-aef8-ac390829af6d.png)

- 응답값 예시
![스크린샷 2022-09-24 오후 3 57 29](https://user-images.githubusercontent.com/24979159/192084639-0e10b960-3d08-4892-b0be-37c076bb1af6.png)

2. restDocs index.adoc 추가
3. redis lock 수정


## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [ ] 구현 기능 테스트


## To Reviewers 🙏
팀원들에게 남길 말
