### PR TITLE
rest docs 불필요한 파라미터 때문에 빌드 에러 발생으로 긴급 수정

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -9,7 +9,7 @@ zerogift(부제)
 
 [[giftBox-API]]
 == 선물함 리스트 API
-operation::giftBox[snippets='http-request,path-parameters,http-response,response-fields']
+operation::giftBox[snippets='http-request,http-response,response-fields']
 
 [[gitBoxDetail-API]]
 == 선물함 상세보기 API


### PR DESCRIPTION
## <rest docs 불필요한 파라미터 때문에 빌드 에러 발생으로 긴급 수정>

## Kinds ✅
- [ ] Feature
- [ ] Bug Fix
- [ ] Infra

## Description ✏
PR에 관한 설명을 작성해주세요.

index.adoc에서 경로를 찾지 못해 에러가 발생하였습니다.
경로를 찾지 못한 파일 삭제

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [ ] 구현 기능 테스트


## To Reviewers 🙏
팀원들에게 남길 말
