### PR TITLE
Product 엔티티 liked 컬럼 삭제 등

### DIFF
--- a/backend/src/main/java/com/zerogift/backend/common/exception/code/ProductErrorCode.java
+++ b/backend/src/main/java/com/zerogift/backend/common/exception/code/ProductErrorCode.java
@@ -12,6 +12,7 @@ public enum ProductErrorCode {
     INSUFFICIENT_AUTHORITY("상품 등록 권한이 없습니다."),
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다."),
     OWNED_BY_SOMEONE_ELSE("상품을 삭제할 권한이 없습니다."),
+    NON_EXISTENT_IMAGE_ID("해당 ID의 이미지가 존재하지 않습니다"),
 
     VOTE_NOT_ALLOWED_FOR_NON_MEMBER("좋아요는 회원만 할 수 있습니다"),
     SELF_VOTE_FORBIDDEN("본인 상품에 좋아요를 할 수 없습니다."),

--- a/backend/src/main/java/com/zerogift/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/com/zerogift/backend/product/controller/ProductController.java
@@ -53,13 +53,6 @@ public class ProductController {
         return productService.searchProduct(q, idx, size);
     }
 
-    @PatchMapping("member/product/like")
-    public ResponseEntity<Result<?>> likeProduct(
-            @RequestParam Long productId,
-            @AuthenticationPrincipal LoginInfo loginInfo) {
-        return productService.likeProduct(productId, loginInfo);
-    }
-
     @GetMapping("product/list")
     public ResponseEntity<Result<?>> listProduct(
             @RequestParam List<Category> categories,

--- a/backend/src/main/java/com/zerogift/backend/product/dto/MyProductDto.java
+++ b/backend/src/main/java/com/zerogift/backend/product/dto/MyProductDto.java
@@ -1,0 +1,25 @@
+package com.zerogift.backend.product.dto;
+
+import com.zerogift.backend.product.type.Category;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Builder
+@Data
+@NoArgsConstructor
+public class MyProductDto {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer price;
+    private Integer inventory;
+    private Category category;
+    private LocalDateTime createdAt;
+    private String mainImageUrl;
+}

--- a/backend/src/main/java/com/zerogift/backend/product/entity/Product.java
+++ b/backend/src/main/java/com/zerogift/backend/product/entity/Product.java
@@ -1,7 +1,6 @@
 package com.zerogift.backend.product.entity;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -10,7 +9,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -50,9 +48,6 @@ public class Product {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
     private String mainImageUrl;
-    @Lob
-    @Builder.Default
-    private HashSet<Long> liked = new HashSet<>();
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;


### PR DESCRIPTION
## Product 엔티티 liked 컬럼 삭제 등

## Kinds ✅
- [ ] Feature
- [x] Bug Fix
- [ ] Infra

## Description ✏
- Product 엔티티에서 안쓰는 liked 컬럼 삭제
- Product 컨트롤러/서비스에서 임시로 넣어놨던 좋아요 관련 기능 삭제
- 내상품 보기 Response에서 재고수량과 생성일 추가

## Changes 🛠
### AS-IS
현재 코드

### TO-BE
변경 코드

## Check List 📝
- [ ] 구현 기능 테스트


## To Reviewers 🙏
팀원들에게 남길 말
